### PR TITLE
Fix bug with presuming service.dependsOn is of type Set

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ export default services => {
 
     const dependents = Object.entries(services).reduce(
       (dependents, [otherName, service]) => {
-        if (service.dependsOn && service.dependsOn.has(name)) {
+        if (service.dependsOn && [...service.dependsOn].includes(name)) {
           dependents.add(otherName);
         }
         return dependents;


### PR DESCRIPTION
While start allows for provision of either an array or set for dependsOn, the stop function assumes a value of type Set, throwing an error when the block is reached.